### PR TITLE
make lease name lowercase

### DIFF
--- a/leaselock.go
+++ b/leaselock.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -42,7 +43,13 @@ type LeaseLock struct {
 }
 
 // newLeaseLock will create a lock of type LeaseLock according to the input parameters
+// nsn will have Name converted to lowercase
 func newLeaseLock(nsn types.NamespacedName, coordinationClient coordinationv1.CoordinationV1Interface, rlc ResourceLockConfig) (Interface, error) {
+	// Transform to lowercase name to conform to requirements
+	nsn = types.NamespacedName{
+		Namespace: nsn.Namespace,
+		Name:      strings.ToLower(nsn.Name),
+	}
 	leaseLock := &LeaseLock{
 		LeaseMeta: metav1.ObjectMeta{
 			Namespace: nsn.Namespace,

--- a/leaselocker.go
+++ b/leaselocker.go
@@ -111,6 +111,7 @@ type LeaseLocker struct {
 
 // NewLeaseLocker creates a new LeaseLocker instance which uses the given rest.Config to create a client to communicate
 // with the k8s API
+// namespacedName will have the Name transformed to lowercase automatically
 func NewLeaseLocker(config *rest.Config, namespacedName types.NamespacedName, owner string) (*LeaseLocker, error) {
 	client, err := clientset.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
Resource names must be lowercase, this forces leases to use a lowercase name
This is also documented in the method comment